### PR TITLE
Add NewLegacyKeccak512 hash function

### DIFF
--- a/sha3/hashes.go
+++ b/sha3/hashes.go
@@ -58,6 +58,12 @@ func New512() hash.Hash {
 // that uses non-standard padding. All other users should use New256 instead.
 func NewLegacyKeccak256() hash.Hash { return &state{rate: 136, outputLen: 32, dsbyte: 0x01} }
 
+// NewLegacyKeccak512 creates a new Keccak-512 hash.
+//
+// Only use this function if you require compatibility with an existing cryptosystem
+// that uses non-standard padding. All other users should use New512 instead.
+func NewLegacyKeccak512() hash.Hash { return &state{rate: 72, outputLen: 64, dsbyte: 0x01} }
+
 // Sum224 returns the SHA3-224 digest of the data.
 func Sum224(data []byte) (digest [28]byte) {
 	h := New224()


### PR DESCRIPTION
Go-Ethereum uses the NewLegacyKeccak512 from an newer version of golang/crypto.

This function is being added here to allow for compatibility with Go-Ethereum and Cosmos-SDK.

Code taken from: https://github.com/golang/crypto/blob/master/sha3/hashes.go#L61-L65