### PR TITLE
cherry pick keccak512 hash

### DIFF
--- a/sha3/hashes.go
+++ b/sha3/hashes.go
@@ -58,6 +58,12 @@ func New512() hash.Hash {
 // that uses non-standard padding. All other users should use New256 instead.
 func NewLegacyKeccak256() hash.Hash { return &state{rate: 136, outputLen: 32, dsbyte: 0x01} }
 
+// NewLegacyKeccak512 creates a new Keccak-512 hash.
+//
+// Only use this function if you require compatibility with an existing cryptosystem
+// that uses non-standard padding. All other users should use New512 instead.
+func NewLegacyKeccak512() hash.Hash { return &state{rate: 72, outputLen: 64, dsbyte: 0x01} }
+
 // Sum224 returns the SHA3-224 digest of the data.
 func Sum224(data []byte) (digest [28]byte) {
 	h := New224()


### PR DESCRIPTION
We want rely on libp2p who relies on multisig relies on this missing method from the latest original golang.org/x/crypto  https://github.com/golang/crypto/blob/4def268fd1a49955bfb3dda92fe3db4f924f2285/sha3/hashes.go#L65

If cosmos-sdk's dependency will switch back to origin crypto OR this repo can do an update, it wouild be better for us:)