### PR TITLE
Remove incorrect import path from package comment

### DIFF
--- a/bcrypt/bcrypt.go
+++ b/bcrypt/bcrypt.go
@@ -5,7 +5,7 @@
 
 // Package bcrypt implements Provos and Mazières's bcrypt adaptive hashing
 // algorithm. See http://www.usenix.org/event/usenix99/provos/provos.pdf
-package bcrypt // import "golang.org/x/crypto/bcrypt"
+package bcrypt
 
 // The code is a port of Provos and Mazières's C implementation.
 import (


### PR DESCRIPTION
This import path caused issues if you use `go mod vendor` and non-go modules mode in any package that has this package as a transitive dependency.