### PR TITLE
openpgp/*: properly invoke .Close on errors

### DIFF
--- a/openpgp/clearsign/clearsign.go
+++ b/openpgp/clearsign/clearsign.go
@@ -265,9 +265,9 @@ func (d *dashEscaper) Write(data []byte) (n int, err error) {
 	return
 }
 
-func (d *dashEscaper) Close() (err error) {
+func (d *dashEscaper) Close() (rerr error) {
 	if !d.atBeginningOfLine {
-		if err = d.buffered.WriteByte(lf); err != nil {
+		if err := d.buffered.WriteByte(lf); err != nil {
 			return
 		}
 	}
@@ -276,6 +276,11 @@ func (d *dashEscaper) Close() (err error) {
 	if err != nil {
 		return
 	}
+	defer func() {
+		if rerr != nil {
+			out.Close()
+		}
+	}()
 
 	t := d.config.Now()
 	for i, k := range d.privateKeys {
@@ -297,10 +302,7 @@ func (d *dashEscaper) Close() (err error) {
 	if err = out.Close(); err != nil {
 		return
 	}
-	if err = d.buffered.Flush(); err != nil {
-		return
-	}
-	return
+	return d.buffered.Flush()
 }
 
 // Encode returns a WriteCloser which will clear-sign a message with privateKey

--- a/openpgp/packet/compressed.go
+++ b/openpgp/packet/compressed.go
@@ -87,11 +87,16 @@ func (cwc compressedWriteCloser) Close() (err error) {
 // can be written and which MUST be closed on completion. If cc is
 // nil, sensible defaults will be used to configure the compression
 // algorithm.
-func SerializeCompressed(w io.WriteCloser, algo CompressionAlgo, cc *CompressionConfig) (literaldata io.WriteCloser, err error) {
+func SerializeCompressed(w io.WriteCloser, algo CompressionAlgo, cc *CompressionConfig) (literaldata io.WriteCloser, rerr error) {
 	compressed, err := serializeStreamHeader(w, packetTypeCompressed)
 	if err != nil {
 		return
 	}
+	defer func() {
+		if rerr != nil {
+			compressed.Close()
+		}
+	}()
 
 	_, err = compressed.Write([]byte{uint8(algo)})
 	if err != nil {

--- a/openpgp/packet/literal.go
+++ b/openpgp/packet/literal.go
@@ -54,7 +54,7 @@ func (l *LiteralData) parse(r io.Reader) (err error) {
 // SerializeLiteral serializes a literal data packet to w and returns a
 // WriteCloser to which the data itself can be written and which MUST be closed
 // on completion. The fileName is truncated to 255 bytes.
-func SerializeLiteral(w io.WriteCloser, isBinary bool, fileName string, time uint32) (plaintext io.WriteCloser, err error) {
+func SerializeLiteral(w io.WriteCloser, isBinary bool, fileName string, time uint32) (plaintext io.WriteCloser, rerr error) {
 	var buf [4]byte
 	buf[0] = 't'
 	if isBinary {
@@ -69,6 +69,11 @@ func SerializeLiteral(w io.WriteCloser, isBinary bool, fileName string, time uin
 	if err != nil {
 		return
 	}
+	defer func() {
+		if rerr != nil {
+			inner.Close()
+		}
+	}()
 
 	_, err = inner.Write(buf[:2])
 	if err != nil {

--- a/openpgp/packet/symmetrically_encrypted.go
+++ b/openpgp/packet/symmetrically_encrypted.go
@@ -253,7 +253,7 @@ func (c noOpCloser) Close() error {
 // to w and returns a WriteCloser to which the to-be-encrypted packets can be
 // written.
 // If config is nil, sensible defaults will be used.
-func SerializeSymmetricallyEncrypted(w io.Writer, c CipherFunction, key []byte, config *Config) (contents io.WriteCloser, err error) {
+func SerializeSymmetricallyEncrypted(w io.Writer, c CipherFunction, key []byte, config *Config) (contents io.WriteCloser, rerr error) {
 	if c.KeySize() != len(key) {
 		return nil, errors.InvalidArgumentError("SymmetricallyEncrypted.Serialize: bad key length")
 	}
@@ -262,6 +262,11 @@ func SerializeSymmetricallyEncrypted(w io.Writer, c CipherFunction, key []byte, 
 	if err != nil {
 		return
 	}
+	defer func() {
+		if rerr != nil {
+			ciphertext.Close()
+		}
+	}()
 
 	_, err = ciphertext.Write([]byte{symmetricallyEncryptedVersion})
 	if err != nil {


### PR DESCRIPTION
Fixes resource leak bugs identified by Orijtech Cyber's
internal team and tooling.

Reported in [golang/go/#53526](https://github.com/golang/go/issues/53526)